### PR TITLE
added manual install option for csoundmagics

### DIFF
--- a/cookbook/05-installingCsoundmagics.ipynb
+++ b/cookbook/05-installingCsoundmagics.ipynb
@@ -5,6 +5,7 @@
    "metadata": {},
    "source": [
     "## Installing CsoundMagics\n",
+    "### Automatic install\n",
     "This cookbook provides an extension for Csound in Jupyter which adds four magics commands, two functions, and one class to the IPython kernel. There is also a Codemirror mode for Csound code syntax highlighting.\n",
     "\n",
     "Download the csoundmagics directory on your system, and from this dir run the command:\n",
@@ -16,6 +17,45 @@
     "This will copy the *csoundmagic* extension in the user's ipython dir, copy the *csound.js* mode in the codemirror mode directory of Jupyter, and copy the *custom.js* file in the user's jupyter dir.\n",
     "\n",
     "See the 06-csoundmagics and 07-icsound notebooks for the use of this extension."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Manual install\n",
+    "In case the installCsoundmagics.py script does not work for your jupyter setup, evaluate the cell below and manually copy *csoundmagics.py*, *csound.js* and *custom.js* to the locations which are reported."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import notebook\n",
+    "import os.path\n",
+    "import site\n",
+    "import shutil\n",
+    "\n",
+    "# Copy csoundmagics in user site-packages dir\n",
+    "dest_magics = site.getusersitepackages()\n",
+    "print('Location for csoundmagics.py:\\n%s' % dest_magics)\n",
+    "#shutil.copy(\"csoundmagics/csoundmagics.py\", dest_magics)\n",
+    "\n",
+    "# Copy csound mode in codemirror\n",
+    "dest_csmode = os.path.join(notebook.DEFAULT_STATIC_FILES_PATH, \"components\", \"codemirror\", \"mode\", \"csound\")\n",
+    "print('Location for csoundmode.js:\\n%s' % dest_csmode)\n",
+    "if not os.path.exists(dest_csmode):\n",
+    "    os.mkdir(dest_csmode)\n",
+    "#shutil.copy(\"csoundmagics/csound.js\", dest_csmode)\n",
+    "\n",
+    "# Copy custom.js in jupyter dir\n",
+    "dest_custom = os.path.join(notebook.extensions.jupyter_config_dir(), \"custom\")\n",
+    "print('Location for custom.js:\\n%s' % dest_custom)\n",
+    "if not os.path.exists(dest_custom):\n",
+    "    os.mkdir(dest_custom)\n",
+    "#shutil.copy(\"csoundmagics/custom.js\", dest_custom)"
    ]
   },
   {
@@ -44,7 +84,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
i just installed the jupyter notebooks on a fresh debian 10, and the install script did not work.  i think the options for the different users are too different.  so i had to figure out the directories.  the goal of this pull request is to make this step easier for others who might have the same problem.

another question would be whether we would not want to make the install itself in this notebook page.  perhaps you did not because of python 2?  i think it would be even easier to have the script content here.  in case you agree, just uncomment the shutil lines.